### PR TITLE
feat(service): add FileProcessingService class

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -7,7 +7,7 @@
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
-          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/unknown/lombok-unknown.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.38/lombok-1.18.38.jar" />
         </processorPath>
         <module name="fileanalyzer" />
       </profile>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/fileanalyzer.iml" filepath="$PROJECT_DIR$/.idea/fileanalyzer.iml" />
+      <module fileurl="file://$PROJECT_DIR$/backend/fileanalyzer/fileanalyzer.iml" filepath="$PROJECT_DIR$/backend/fileanalyzer/fileanalyzer.iml" />
     </modules>
   </component>
 </project>

--- a/backend/fileanalyzer/src/main/java/com/infina/fileanalyzer/service/FileProcessingService.java
+++ b/backend/fileanalyzer/src/main/java/com/infina/fileanalyzer/service/FileProcessingService.java
@@ -1,0 +1,59 @@
+package com.infina.fileanalyzer.service;
+
+import com.infina.fileanalyzer.entity.FileStats;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.concurrent.Callable;
+
+public class FileProcessingService {
+
+    /**
+     * Calculates the line and character count for the given file,
+     * and returns processing information via FileStats.
+     * Only .txt files are allowed.
+     */
+    public FileStats analyzeFile(Path filePath) throws IOException {
+        // Extension check: Only .txt files are processed.
+        String fileName = filePath.getFileName().toString();
+        if (!fileName.toLowerCase().endsWith(".txt")) {
+            throw new IllegalArgumentException("Only .txt files can be analyzed.");
+        }
+
+        FileStats stats = new FileStats();
+        stats.setFileName(fileName);
+        stats.setThreadName(Thread.currentThread().getName());
+        stats.setProcessingStartTime(LocalDateTime.now());
+
+        // Calculate line and character count
+        int lineCount = countLines(filePath);
+        int characterCount = countCharacters(filePath);
+
+        stats.setLineCount(lineCount);
+        stats.setCharacterCount(characterCount);
+
+        stats.setProcessingEndTime(LocalDateTime.now());
+        stats.setProcessingCompleted(true);
+
+        return stats;
+    }
+
+    // Calculates the line count of the file
+    private int countLines(Path filePath) throws IOException {
+        try (var lines = Files.lines(filePath)) {
+            return (int) lines.count();
+        }
+    }
+
+    // Calculates the total character count of the file
+    private int countCharacters(Path filePath) throws IOException {
+        return Files.readString(filePath).length();
+    }
+
+    // Can be used to run with thread pools
+    public Callable<FileStats> analyzeFileCallable(Path filePath) {
+        return () -> analyzeFile(filePath);
+    }
+}


### PR DESCRIPTION
 What does this PR do?

- Implements the `FileProcessingService` class under `service` package.
- Adds file analysis logic: line and character counting, .txt validation, and thread information for each process.

 Why is it needed?

- Required for handling file analysis tasks in a modular and reusable way.
- Prepares the backend for further integration with other analysis/reporting modules.

---

Please review and let me know if any improvements are needed!
